### PR TITLE
Add Agents for N-Queens Problem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: animations
+          name: vacuums
           path: |
             ./vacuum1.gif
             ./vacuum2.gif
@@ -66,7 +66,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: animations
+          name: hill_climbing_queens
           path: |
             ./hill_climbing_8.gif
             ./hill_climbing_16.gif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             ./vacuum3.gif
 
   nqueens:
-    name: Vacuum Agents
+    name: Hill Climbing N-Queens Agents
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,27 @@ jobs:
             ./vacuum1.gif
             ./vacuum2.gif
             ./vacuum3.gif
+
+  nqueens:
+    name: Vacuum Agents
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        n_queens: [8, 16, 32]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        run: pip install -r requirements.txt
+      - name: Clean
+        run: python nqueens.py ${{matrix.n_queens}}
+      - name: Animation Output
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: animations
+          path: |
+            ./hill_climbing_8.gif
+            ./hill_climbing_16.gif
+            ./hill_climbing_32.gif

--- a/cap6635/README.md
+++ b/cap6635/README.md
@@ -29,3 +29,13 @@ Run the `vacuums.py` example with the optional paramters.  The output gets saved
 
 python vacuums.py [type_of_agent] [height_of_world] [width_of_world]
 ```
+
+### n-Queens
+
+```bash
+# Hill Climbing
+python nqueens.py [number_of_queens]
+
+# Simulated Annealing
+python simulated_annealing.py [number_of_queens]
+```

--- a/cap6635/agents/README.md
+++ b/cap6635/agents/README.md
@@ -23,3 +23,16 @@ Code Adapted from Dr. Zhu's adaptation of: https://github.com/mawippel/python-va
 - Utility-based Agents: Agents 'look for' goal while considering other factors.  The utility function is an optimization of many variables.
 
   (not yet implemented)
+
+### Hill Climbing + Simulated Annealing (n-Queens)
+
+Code Adapted from Dr. Zhu's adaptation of: https://github.com/TranDatDT/n-queens-simulated-annealing/blob/master/main.py
+
+- Hill Climbing: Agents look at all of it's successors and always chooses the best next move.  If there are multiple 'best' moves, choose randomly between them.  Downfalls: local max/min, plateaus, ridges
+
+- Simulated Annealing: Agents pick a random successor.  If it is 'within reason', then choose it; otherwise, check the next random successor.  Successors are evaluated against the temperature.  A higher temperature increases the likelihood of a bad move.  As the temperature cools with each iteration, simulated annealing tends toward hill climbing naturally.
+
+Necessary features of the environment:
+- `random_init`: Allows for random restart to cover downfalls
+- `eval_cost`: Decides if a solution was reached
+- `successors`: Enumerates all of the next moves

--- a/cap6635/agents/informed/hill_climbing.py
+++ b/cap6635/agents/informed/hill_climbing.py
@@ -1,0 +1,31 @@
+
+from copy import deepcopy
+
+
+class HillClimbing():
+
+    def __init__(self, board):
+        self._solution_located = False
+        self._board = board
+        self._answer = board._chess_board
+        self._cost = [self._board.total_tension(self._answer)]
+
+    def random_init(self):
+        self._board.random_init()
+        self._answer = self._board._chess_board
+        self._cost = [self._board.total_tension(self._answer)]
+
+    def climb(self):
+        for pair in self._board.successors():
+            new_position = deepcopy(self._answer)
+            old_pair = new_position[pair[0]]
+            new_position[pair[0]] = new_position[pair[1]]
+            new_position[pair[1]] = old_pair
+            new_cost = self._board.total_tension(new_position)
+            if new_cost < self._cost[-1]:
+                self._answer = new_position
+                self._cost.append(new_cost)
+                if self._cost[-1] == 0:
+                    self._solution_located = True
+                self.climb()
+        return "Failed"

--- a/cap6635/agents/informed/hill_climbing.py
+++ b/cap6635/agents/informed/hill_climbing.py
@@ -27,5 +27,6 @@ class HillClimbing():
                 self._cost.append(new_cost)
                 if self._cost[-1] == 0:
                     self._solution_located = True
+                    self._board._chess_board = self._answer
                 self.climb()
         return "Failed"

--- a/cap6635/agents/informed/hill_climbing.py
+++ b/cap6635/agents/informed/hill_climbing.py
@@ -1,5 +1,6 @@
 
 from copy import deepcopy
+import random
 
 
 class HillClimbing():
@@ -16,7 +17,10 @@ class HillClimbing():
         self._cost = [self._board.total_tension(self._answer)]
 
     def climb(self):
-        for pair in self._board.successors():
+        pairs = self._board.successors()
+        for i in range(len(pairs)):
+            pair = random.choice(pairs)
+            pairs.remove(pair)
             new_position = deepcopy(self._answer)
             old_pair = new_position[pair[0]]
             new_position[pair[0]] = new_position[pair[1]]

--- a/cap6635/agents/informed/hill_climbing.py
+++ b/cap6635/agents/informed/hill_climbing.py
@@ -9,12 +9,12 @@ class HillClimbing():
         self._solution_located = False
         self._board = board
         self._answer = board._chess_board
-        self._cost = [self._board.total_tension(self._answer)]
+        self._cost = [self._board.eval_cost(self._answer)]
 
     def random_init(self):
         self._board.random_init()
         self._answer = self._board._chess_board
-        self._cost = [self._board.total_tension(self._answer)]
+        self._cost = [self._board.eval_cost(self._answer)]
 
     def climb(self):
         pairs = self._board.successors()
@@ -25,7 +25,7 @@ class HillClimbing():
             old_pair = new_position[pair[0]]
             new_position[pair[0]] = new_position[pair[1]]
             new_position[pair[1]] = old_pair
-            new_cost = self._board.total_tension(new_position)
+            new_cost = self._board.eval_cost(new_position)
             if new_cost < self._cost[-1]:
                 self._answer = new_position
                 self._cost.append(new_cost)

--- a/cap6635/agents/informed/queens.py
+++ b/cap6635/agents/informed/queens.py
@@ -1,0 +1,72 @@
+
+from copy import deepcopy
+from itertools import combinations
+import random
+
+
+class NQueens:
+
+    def __init__(self, n):
+        self._n = n
+        self._chess_board = {}
+        self.random_init()
+
+    def max_cost(self):
+        return self._n * (self._n - 1)
+
+    def random_init(self):
+        rows = list(range(self._n))
+        random.shuffle(rows)
+        for column in range(self._n):
+            self._chess_board[column] = random.choice(rows)
+            rows.remove(self._chess_board[column])
+
+    def royal_tension(self, q1, q2):
+        ''' 1 if queens threaten each other, otherwise 0'''
+        if q1[0] == q2[0]:
+            return 1
+        if q1[1] == q2[1]:
+            return 1
+        if abs(q1[0] - q2[0]) == abs(q1[1] - q2[1]):
+            return 1
+        return 0
+
+    def total_tension(self, board):
+        tension = 0
+        indexes = [(col, row) for col, row in board.items()]
+        for pair in list(combinations(indexes, 2)):
+            tension += self.royal_tension(pair[0], pair[1])
+        return tension
+
+    def successors(self):
+        ''' All successor swaps '''
+        return list(combinations(list(range(self._n)), 2))
+
+
+class HillClimbingQueens(NQueens):
+
+    def __init__(self, n):
+        super(HillClimbingQueens, self).__init__(n)
+        self._solution_located = False
+        self._answer = self._chess_board
+        self._cost = [self.total_tension(self._answer)]
+
+    def random_init(self):
+        super(HillClimbingQueens, self).random_init()
+        self._answer = self._chess_board
+        self._cost = [self.total_tension(self._answer)]
+
+    def climb(self):
+        for pair in super(HillClimbingQueens, self).successors():
+            new_position = deepcopy(self._answer)
+            old_pair = new_position[pair[0]]
+            new_position[pair[0]] = new_position[pair[1]]
+            new_position[pair[1]] = old_pair
+            new_cost = self.total_tension(new_position)
+            if new_cost < self._cost[-1]:
+                self._answer = new_position
+                self._cost.append(new_cost)
+                if self._cost[-1] == 0:
+                    self._solution_located = True
+                self.climb()
+        return "Failed"

--- a/cap6635/agents/informed/simulated_annealing.py
+++ b/cap6635/agents/informed/simulated_annealing.py
@@ -13,12 +13,12 @@ class SimulatedAnnealing():
         self._starting_temperature = temperature
         self._t = self._starting_temperature
         self._cooling_rate = cooling_rate
-        self._cost = [self._board.total_tension(self._answer)]
+        self._cost = [self._board.eval_cost(self._answer)]
 
     def random_init(self):
         self._board.random_init()
         self._answer = self._board._chess_board
-        self._cost = [self._board.total_tension(self._answer)]
+        self._cost = [self._board.eval_cost(self._answer)]
         self._t = self._starting_temperature
 
     def anneal(self):
@@ -32,7 +32,7 @@ class SimulatedAnnealing():
                 old_pair = new_position[pair[0]]
                 new_position[pair[0]] = new_position[pair[1]]
                 new_position[pair[1]] = old_pair
-                new_cost = self._board.total_tension(new_position)
+                new_cost = self._board.eval_cost(new_position)
                 delta = new_cost - self._cost[-1]
                 if delta < 0 or (random.uniform(0, 1) < exp(-delta / self._t)):
                     self._answer = new_position

--- a/cap6635/agents/informed/simulated_annealing.py
+++ b/cap6635/agents/informed/simulated_annealing.py
@@ -1,0 +1,44 @@
+
+from copy import deepcopy
+from math import exp
+import random
+
+
+class SimulatedAnnealing():
+
+    def __init__(self, board, temperature, cooling_rate=0.99):
+        self._solution_located = False
+        self._board = board
+        self._answer = board._chess_board
+        self._starting_temperature = temperature
+        self._t = self._starting_temperature
+        self._cooling_rate = cooling_rate
+        self._cost = [self._board.total_tension(self._answer)]
+
+    def random_init(self):
+        self._board.random_init()
+        self._answer = self._board._chess_board
+        self._cost = [self._board.total_tension(self._answer)]
+        self._t = self._starting_temperature
+
+    def anneal(self):
+        while self._t > 0.0000001:
+            self._t *= self._cooling_rate
+            pairs = self._board.successors()
+            for i in range(len(pairs)):
+                pair = random.choice(pairs)
+                pairs.remove(pair)
+                new_position = deepcopy(self._answer)
+                old_pair = new_position[pair[0]]
+                new_position[pair[0]] = new_position[pair[1]]
+                new_position[pair[1]] = old_pair
+                new_cost = self._board.total_tension(new_position)
+                delta = new_cost - self._cost[-1]
+                if delta < 0 or (random.uniform(0, 1) < exp(-delta / self._t)):
+                    self._answer = new_position
+                    self._cost.append(new_cost)
+                    if self._cost[-1] == 0:
+                        self._solution_located = True
+                        self._board._chess_board = self._answer
+                    return True
+        return False

--- a/cap6635/environment/queens.py
+++ b/cap6635/environment/queens.py
@@ -30,7 +30,7 @@ class NQueens:
             return 1
         return 0
 
-    def total_tension(self, board):
+    def eval_cost(self, board):
         tension = 0
         indexes = [(col, row) for col, row in board.items()]
         for pair in list(combinations(indexes, 2)):

--- a/cap6635/environment/queens.py
+++ b/cap6635/environment/queens.py
@@ -1,5 +1,4 @@
 
-from copy import deepcopy
 from itertools import combinations
 import random
 
@@ -41,32 +40,3 @@ class NQueens:
     def successors(self):
         ''' All successor swaps '''
         return list(combinations(list(range(self._n)), 2))
-
-
-class HillClimbingQueens(NQueens):
-
-    def __init__(self, n):
-        super(HillClimbingQueens, self).__init__(n)
-        self._solution_located = False
-        self._answer = self._chess_board
-        self._cost = [self.total_tension(self._answer)]
-
-    def random_init(self):
-        super(HillClimbingQueens, self).random_init()
-        self._answer = self._chess_board
-        self._cost = [self.total_tension(self._answer)]
-
-    def climb(self):
-        for pair in super(HillClimbingQueens, self).successors():
-            new_position = deepcopy(self._answer)
-            old_pair = new_position[pair[0]]
-            new_position[pair[0]] = new_position[pair[1]]
-            new_position[pair[1]] = old_pair
-            new_cost = self.total_tension(new_position)
-            if new_cost < self._cost[-1]:
-                self._answer = new_position
-                self._cost.append(new_cost)
-                if self._cost[-1] == 0:
-                    self._solution_located = True
-                self.climb()
-        return "Failed"

--- a/cap6635/utilities/README.md
+++ b/cap6635/utilities/README.md
@@ -24,3 +24,6 @@
 
 ### Finding pairs between numbers
 - https://www.geeksforgeeks.org/python-all-possible-pairs-in-list/
+
+### Hill-climbing algorithms
+- https://www.geeksforgeeks.org/introduction-hill-climbing-artificial-intelligence/

--- a/cap6635/utilities/README.md
+++ b/cap6635/utilities/README.md
@@ -21,3 +21,6 @@
   - Compiling pictures into a GIF
   - https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v2.mimwrite.html
     - official docs
+
+### Finding pairs between numbers
+- https://www.geeksforgeeks.org/python-all-possible-pairs-in-list/

--- a/cap6635/utilities/plot.py
+++ b/cap6635/utilities/plot.py
@@ -2,6 +2,7 @@
 from cap6635.utilities.location import generateNumber
 
 import matplotlib.pyplot as plt
+import numpy as np
 import imageio
 import os
 import shutil
@@ -49,4 +50,35 @@ class VacuumAnimator(Animator):
         plt.plot(agent.y_path, agent.x_path, 'r:', linewidth=1)
         plt.plot(agent.y_path[-1], agent.x_path[-1], '*r', 'Robot field', 5)
         plt.savefig(self._temp_dir + '%s.png' % (generateNumber(i)))
+        plt.clf()
+
+
+class QueensAnimator(Animator):
+
+    def save_state(self, t, board, cost):
+        label = "Iteration: %d" % (t)
+        n = board._n
+        pretty = np.arange(n*n*3).reshape(n, n, 3)
+        positions = [(row, col) for row, col in board._chess_board.items()]
+
+        ax1 = plt.subplot(121)
+        for pos in np.linspace(-n, 2*n, 3*n+1):
+            ax1.vlines(pos, 0, n, color='k', linestyle='--')
+            ax1.hlines(pos, 0, n, color='k', linestyle='--')
+        for pos in np.linspace(-n, 2*n, 3*n*10+1):
+            ax1.axline((pos, 0), slope=1, color='k', linestyle='-', transform=ax1.transAxes)
+            ax1.axline((pos, 0), slope=-1, color='k', linestyle='-', transform=ax1.transAxes)
+        for i in range(n):
+            for j in range(n):
+                if (i, j) in positions:
+                    pretty[i][j] = (255, 0, 0)
+                else:
+                    pretty[i][j] = (255, 255, 255)
+        ax1.imshow(pretty)
+        ax2 = plt.subplot(122)
+        ax2.plot(cost)
+        ax2.set_xlabel('# of Moves')
+        ax2.set_ylabel('# of attacked Q pairs')
+        plt.title(label)
+        plt.savefig(self._temp_dir + '%s.png' % (generateNumber(t)))
         plt.clf()

--- a/cap6635/utilities/plot.py
+++ b/cap6635/utilities/plot.py
@@ -66,8 +66,10 @@ class QueensAnimator(Animator):
             ax1.vlines(pos, 0, n, color='k', linestyle='--')
             ax1.hlines(pos, 0, n, color='k', linestyle='--')
         for pos in np.linspace(-n, 2*n, 3*n*10+1):
-            ax1.axline((pos, 0), slope=1, color='k', linestyle='-', transform=ax1.transAxes)
-            ax1.axline((pos, 0), slope=-1, color='k', linestyle='-', transform=ax1.transAxes)
+            ax1.axline((pos, 0), slope=1,
+                       color='k', linestyle='-', transform=ax1.transAxes)
+            ax1.axline((pos, 0), slope=-1,
+                       color='k', linestyle='-', transform=ax1.transAxes)
         for i in range(n):
             for j in range(n):
                 if (i, j) in positions:

--- a/nqueens.py
+++ b/nqueens.py
@@ -18,7 +18,7 @@ agent = HillClimbing(board)
 
 last_cost = agent._cost
 i = 0
-animator = QueensAnimator(os.getcwd(), '/hill_climbing.gif')
+animator = QueensAnimator(os.getcwd(), '/hill_climbing_%d.gif' % (board._n))
 animator.temp = '/temp/'
 animator.save_state(i, agent._board, agent._cost)
 while not agent._solution_located:

--- a/nqueens.py
+++ b/nqueens.py
@@ -1,0 +1,24 @@
+
+import os
+import random
+import sys
+
+from cap6635.agents.informed.queens import (
+    HillClimbingQueens
+)
+from cap6635.utilities.plot import VacuumAnimator
+
+
+agent = HillClimbingQueens(32)
+
+last_cost = agent._cost
+repetitions = 0
+while not agent._solution_located:
+    print(repetitions)
+    result = agent.climb()
+    if result == 'Failed':
+        agent.random_init()
+        repetitions += 1
+    last_cost = agent._cost
+
+print(agent._answer)

--- a/nqueens.py
+++ b/nqueens.py
@@ -3,13 +3,15 @@ import os
 import random
 import sys
 
-from cap6635.agents.informed.queens import (
-    HillClimbingQueens
+from cap6635.agents.informed.hill_climbing import (
+    HillClimbing
 )
+from cap6635.environment.queens import NQueens
 from cap6635.utilities.plot import VacuumAnimator
 
 
-agent = HillClimbingQueens(32)
+board = NQueens(20)
+agent = HillClimbing(board)
 
 last_cost = agent._cost
 repetitions = 0

--- a/nqueens.py
+++ b/nqueens.py
@@ -7,20 +7,27 @@ from cap6635.agents.informed.hill_climbing import (
     HillClimbing
 )
 from cap6635.environment.queens import NQueens
-from cap6635.utilities.plot import VacuumAnimator
+from cap6635.utilities.plot import QueensAnimator
 
 
 board = NQueens(20)
 agent = HillClimbing(board)
 
 last_cost = agent._cost
-repetitions = 0
+i = 0
+animator = QueensAnimator(os.getcwd(), '/hill_climbing.gif')
+animator.temp = '/temp/'
+animator.save_state(i, agent._board, agent._cost)
 while not agent._solution_located:
-    print(repetitions)
+    print(i)
     result = agent.climb()
     if result == 'Failed':
+        animator.save_state(i, agent._board, agent._cost)
         agent.random_init()
-        repetitions += 1
+        i += 1
     last_cost = agent._cost
+
+animator.make_gif()
+del animator.temp
 
 print(agent._answer)

--- a/nqueens.py
+++ b/nqueens.py
@@ -10,7 +10,10 @@ from cap6635.environment.queens import NQueens
 from cap6635.utilities.plot import QueensAnimator
 
 
-board = NQueens(20)
+try:
+    board = NQueens(int(sys.argv[1]))
+except IndexError:
+    board = NQueens(random.randint(4, 30))
 agent = HillClimbing(board)
 
 last_cost = agent._cost

--- a/simulated_annealing.py
+++ b/simulated_annealing.py
@@ -3,7 +3,7 @@ import os
 import random
 import sys
 
-from cap6635.agents.informed.hill_climbing import HillClimbing
+from cap6635.agents.informed.simulated_annealing import SimulatedAnnealing
 from cap6635.environment.queens import NQueens
 from cap6635.utilities.plot import QueensAnimator
 
@@ -12,17 +12,24 @@ try:
     board = NQueens(int(sys.argv[1]))
 except IndexError:
     board = NQueens(random.randint(4, 30))
-agent = HillClimbing(board)
+agent = SimulatedAnnealing(board, temperature=40)
 
 last_cost = agent._cost
 i = 0
-animator = QueensAnimator(os.getcwd(), '/hill_climbing_%d.gif' % (board._n))
+animator = QueensAnimator(os.getcwd(),
+                          '/simulated_annealing_%d.gif' % (board._n))
 animator.temp = '/temp/'
 animator.save_state(i, agent._board, agent._cost)
 while not agent._solution_located:
-    print(i)
-    result = agent.climb()
-    if result == 'Failed':
+    result = agent.anneal()
+    if result:
+        if agent._solution_located:
+            print(i)
+            animator.save_state(i, agent._board, agent._cost)
+            break
+        result = agent.anneal()
+    else:
+        print(i)
         animator.save_state(i, agent._board, agent._cost)
         agent.random_init()
         i += 1


### PR DESCRIPTION
Notes:
- Add `NQueens` environment layout
  - Compute threat from attacking queens
  - Generate random board
  - Generate list of successor moves
- Add `HillClimbing` agent
  - Define random init to start over
  - Perform the "climb"
    - Find all the successors
    - For each successor, test the cost.  If the cost is less, choose that successor.
    - If the cost is zero, solution is found.
    - If no better successors, perform start over.
- Add test script for hill-climbing n-queens problem
- Add `QueensAnimator` to plot solution for n-queens problem and the number of moves it took to get there
- Add github action test for different n-queen boards.